### PR TITLE
Fix integration test retry timing for eventual consistency

### DIFF
--- a/tests/integration/test_portfolio.py
+++ b/tests/integration/test_portfolio.py
@@ -10,8 +10,8 @@ def _eventually_fetch(
     fetch,
     *,
     predicate=lambda result: True,
-    timeout: float = 3.0,
-    interval: float = 0.25,
+    timeout: float = 30.0,
+    interval: float = 5.0,
     ignored_exceptions: tuple[type[Exception], ...] = (),
 ):
     """Retry a read until it succeeds and satisfies the predicate."""


### PR DESCRIPTION
## Summary
- Increased `_eventually_fetch` default timeout from 3s to 30s and interval from 0.25s to 5s in `tests/integration/test_portfolio.py`
- Fixes `test_get_order_by_id` which was failing because the Kalshi query-exchange service has eventual consistency and 3 seconds wasn't enough time for newly placed orders to become fetchable by ID

## Test plan
- [ ] Run `pytest tests/integration/test_portfolio.py::TestOrderMutations::test_get_order_by_id -v` and verify it passes consistently
- [ ] Run full integration suite `pytest tests/integration/ -v` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)