### PR TITLE
Treat null list-typed responses as empty (1.0.6)

### DIFF
--- a/pykalshi/__init__.py
+++ b/pykalshi/__init__.py
@@ -4,7 +4,7 @@ Kalshi API Client Library
 A clean, modular interface for the Kalshi trading API.
 """
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 import logging
 

--- a/pykalshi/_async/api_keys.py
+++ b/pykalshi/_async/api_keys.py
@@ -17,7 +17,7 @@ class AsyncAPIKeys:
     async def list(self) -> list[APIKey]:
         """List all API keys for this account."""
         data = await self._client.get("/api_keys")
-        return [APIKey.model_validate(k) for k in data.get("api_keys", [])]
+        return [APIKey.model_validate(k) for k in (data.get("api_keys") or [])]
 
     async def create(self, public_key: str, name: str | None = None) -> str:
         """Create an API key with a provided RSA public key.

--- a/pykalshi/_async/client.py
+++ b/pykalshi/_async/client.py
@@ -156,7 +156,7 @@ class AsyncKalshiClient(_BaseKalshiClient):
             filtered = {k: v for k, v in params.items() if v is not None}
             endpoint = f"{path}?{urlencode(filtered)}" if filtered else path
             response = await self.get(endpoint)
-            all_items.extend(response.get(response_key, []))
+            all_items.extend(response.get(response_key) or [])
             cursor = response.get("cursor", "")
             if not fetch_all or not cursor:
                 break
@@ -409,5 +409,5 @@ class AsyncKalshiClient(_BaseKalshiClient):
         response = await self.get(f"/markets/candlesticks?{query}")
         return {
             item["market_ticker"]: CandlestickResponse.model_validate(item)
-            for item in response.get("markets", [])
+            for item in (response.get("markets") or [])
         }

--- a/pykalshi/_async/exchange.py
+++ b/pykalshi/_async/exchange.py
@@ -39,7 +39,7 @@ class AsyncExchange:
     async def get_announcements(self) -> list[Announcement]:
         """Get exchange-wide announcements."""
         data = await self._client.get("/exchange/announcements")
-        return [Announcement.model_validate(a) for a in data.get("announcements", [])]
+        return [Announcement.model_validate(a) for a in (data.get("announcements") or [])]
 
     async def get_user_data_timestamp(self) -> int:
         """Get timestamp of last user data validation (Unix ms)."""

--- a/pykalshi/_async/history.py
+++ b/pykalshi/_async/history.py
@@ -92,7 +92,7 @@ class AsyncHistory:
         )
         return [
             HistoricalCandlestick.model_validate(c)
-            for c in response.get("candlesticks", [])
+            for c in (response.get("candlesticks") or [])
         ]
 
     async def get_fills(

--- a/pykalshi/_async/portfolio.py
+++ b/pykalshi/_async/portfolio.py
@@ -317,7 +317,7 @@ class AsyncPortfolio:
         prepared = self._build_batch_orders(orders)
         response = await self._client.post("/portfolio/orders/batched", {"orders": prepared})
         result = []
-        for item in response.get("orders", []):
+        for item in (response.get("orders") or []):
             order_data = item.get("order")
             if order_data is None:
                 continue
@@ -336,7 +336,7 @@ class AsyncPortfolio:
         orders = [{"order_id": oid} for oid in order_ids]
         response = await self._client.delete("/portfolio/orders/batched", {"orders": orders})
         result = []
-        for item in response.get("orders", []):
+        for item in (response.get("orders") or []):
             order_data = item.get("order")
             if order_data is None:
                 continue
@@ -373,7 +373,7 @@ class AsyncPortfolio:
         response = await self._client.get(endpoint)
         return DataFrameList(
             QueuePositionModel.model_validate(qp)
-            for qp in response.get("queue_positions", [])
+            for qp in (response.get("queue_positions") or [])
         )
 
     # --- Settlements ---
@@ -438,7 +438,7 @@ class AsyncPortfolio:
         response = await self._client.get("/portfolio/order_groups")
         return DataFrameList(
             OrderGroupModel.model_validate(og)
-            for og in response.get("order_groups", [])
+            for og in (response.get("order_groups") or [])
         )
 
     async def reset_order_group(self, order_group_id: str) -> None:
@@ -488,7 +488,7 @@ class AsyncPortfolio:
         response = await self._client.get("/portfolio/subaccounts/balances")
         return DataFrameList(
             SubaccountBalanceModel.model_validate(b)
-            for b in response.get("balances", [])
+            for b in (response.get("balances") or [])
         )
 
     async def get_subaccount_transfers(

--- a/pykalshi/_sync/api_keys.py
+++ b/pykalshi/_sync/api_keys.py
@@ -19,7 +19,7 @@ class APIKeys:
     def list(self) -> list[APIKey]:
         """List all API keys for this account."""
         data = self._client.get("/api_keys")
-        return [APIKey.model_validate(k) for k in data.get("api_keys", [])]
+        return [APIKey.model_validate(k) for k in (data.get("api_keys") or [])]
 
     def create(self, public_key: str, name: str | None = None) -> str:
         """Create an API key with a provided RSA public key.

--- a/pykalshi/_sync/client.py
+++ b/pykalshi/_sync/client.py
@@ -158,7 +158,7 @@ class KalshiClient(_BaseKalshiClient):
             filtered = {k: v for k, v in params.items() if v is not None}
             endpoint = f"{path}?{urlencode(filtered)}" if filtered else path
             response = self.get(endpoint)
-            all_items.extend(response.get(response_key, []))
+            all_items.extend(response.get(response_key) or [])
             cursor = response.get("cursor", "")
             if not fetch_all or not cursor:
                 break
@@ -411,5 +411,5 @@ class KalshiClient(_BaseKalshiClient):
         response = self.get(f"/markets/candlesticks?{query}")
         return {
             item["market_ticker"]: CandlestickResponse.model_validate(item)
-            for item in response.get("markets", [])
+            for item in (response.get("markets") or [])
         }

--- a/pykalshi/_sync/exchange.py
+++ b/pykalshi/_sync/exchange.py
@@ -41,7 +41,7 @@ class Exchange:
     def get_announcements(self) -> list[Announcement]:
         """Get exchange-wide announcements."""
         data = self._client.get("/exchange/announcements")
-        return [Announcement.model_validate(a) for a in data.get("announcements", [])]
+        return [Announcement.model_validate(a) for a in (data.get("announcements") or [])]
 
     def get_user_data_timestamp(self) -> int:
         """Get timestamp of last user data validation (Unix ms)."""

--- a/pykalshi/_sync/history.py
+++ b/pykalshi/_sync/history.py
@@ -94,7 +94,7 @@ class History:
         )
         return [
             HistoricalCandlestick.model_validate(c)
-            for c in response.get("candlesticks", [])
+            for c in (response.get("candlesticks") or [])
         ]
 
     def get_fills(

--- a/pykalshi/_sync/portfolio.py
+++ b/pykalshi/_sync/portfolio.py
@@ -319,7 +319,7 @@ class Portfolio:
         prepared = self._build_batch_orders(orders)
         response = self._client.post("/portfolio/orders/batched", {"orders": prepared})
         result = []
-        for item in response.get("orders", []):
+        for item in (response.get("orders") or []):
             order_data = item.get("order")
             if order_data is None:
                 continue
@@ -338,7 +338,7 @@ class Portfolio:
         orders = [{"order_id": oid} for oid in order_ids]
         response = self._client.delete("/portfolio/orders/batched", {"orders": orders})
         result = []
-        for item in response.get("orders", []):
+        for item in (response.get("orders") or []):
             order_data = item.get("order")
             if order_data is None:
                 continue
@@ -375,7 +375,7 @@ class Portfolio:
         response = self._client.get(endpoint)
         return DataFrameList(
             QueuePositionModel.model_validate(qp)
-            for qp in response.get("queue_positions", [])
+            for qp in (response.get("queue_positions") or [])
         )
 
     # --- Settlements ---
@@ -440,7 +440,7 @@ class Portfolio:
         response = self._client.get("/portfolio/order_groups")
         return DataFrameList(
             OrderGroupModel.model_validate(og)
-            for og in response.get("order_groups", [])
+            for og in (response.get("order_groups") or [])
         )
 
     def reset_order_group(self, order_group_id: str) -> None:
@@ -490,7 +490,7 @@ class Portfolio:
         response = self._client.get("/portfolio/subaccounts/balances")
         return DataFrameList(
             SubaccountBalanceModel.model_validate(b)
-            for b in response.get("balances", [])
+            for b in (response.get("balances") or [])
         )
 
     def get_subaccount_transfers(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pykalshi"
-version = "1.0.5"
+version = "1.0.6"
 description = "A typed Python client for the Kalshi prediction markets API with WebSocket streaming, automatic retries, and ergonomic interfaces"
 readme = "README.md"
 license = "MIT"

--- a/tests/integration/test_portfolio.py
+++ b/tests/integration/test_portfolio.py
@@ -531,8 +531,11 @@ class TestOrderMutations:
         assert isinstance(queue_pos.queue_position_fp, str)
         assert float(queue_pos.queue_position_fp) >= 0
 
-        # Cleanup
-        order.cancel()
+        # Cleanup (order may already be filled/gone)
+        try:
+            order.cancel()
+        except ResourceNotFoundError:
+            pass
 
     def test_get_queue_positions_multiple(self, client, market_for_orders):
         """Get queue positions for all resting orders (filtered by market)."""

--- a/uv.lock
+++ b/uv.lock
@@ -1296,7 +1296,7 @@ wheels = [
 
 [[package]]
 name = "pykalshi"
-version = "0.3.7"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1341,7 +1341,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pykalshi", extras = ["dataframe"], marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
- Kalshi's API sometimes returns ``{\"key\": null}`` for list-typed payload fields instead of ``{\"key\": []}`` or omitting the key. ``dict.get(key, [])`` only falls back to ``[]`` for missing keys — when the key is present with value ``null``, iteration crashes with ``TypeError: 'NoneType' object is not iterable``. This caused the integration suite's ``test_get_queue_positions_multiple`` failure on PR #19's CI run.
- Switches every list-extraction call site to ``dict.get(key) or []`` so both null and missing are handled.
- Covers 13 sites: paginated list helper, multi-market candlesticks, batch order place/cancel, queue positions, order groups, subaccount balances, historical candlesticks, exchange announcements, and api_keys list (sync + async pairs).
- Also stops ``test_get_queue_position``'s cleanup from raising when the order was already filled mid-test.

Bumps version to **1.0.6**.

## Test plan
- [x] ``pytest tests/`` (unit) — 301 passed
- [ ] CI integration tests — should now pass since the queue_positions failure is the regression this PR fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)